### PR TITLE
feat(instance): protect init route with a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,20 @@ An implementation of [Baileys](https://github.com/adiwajshing/Baileys/) as a sim
 
 Edit environment variables on `.env`
 
+```
+Important: You must set TOKEN= to a random string to protect the init route.
+```
+
 ```env
+# ==================================
+# SECURITY CONFIGURATION
+# ==================================
+TOKEN=RANDOM_TOKEN_HERE
+
 # ==================================
 # APPLICATION CONFIGURATION
 # ==================================
-PORT=3000
+PORT=3333
 
 # ==================================
 # DATABASE CONFIGURATION
@@ -62,7 +71,7 @@ To generate an Instance Key
 Using the route:
 
 ```bash
-curl --location --request GET 'localhost:3333/instance/init' \
+curl --location --request GET 'localhost:3333/instance/init?token=RANDOM_TOKEN_HERE' \
 --data-raw ''
 ```
 
@@ -72,7 +81,7 @@ To generate a Custom Instance
 Using the route:
 
 ```bash
-curl --location --request GET 'http://localhost:3000/instance/init?key=CUSTOM_INSTANCE_KEY_HERE&webhook=true&webhookUrl=https://webhook.site/d7114704-97f6-4562-9a47-dcf66b07266d' \
+curl --location --request GET 'localhost:3333/instance/init?token=RANDOM_TOKEN_HERE&key=CUSTOM_INSTANCE_KEY_HERE&webhook=true&webhookUrl=https://webhook.site/d7114704-97f6-4562-9a47-dcf66b07266d' \
 --data-raw ''
 ```
 
@@ -93,15 +102,15 @@ Save the value of the `key` from response. Then use this value to call all the r
 ## Examples
 
 ```sh
-#Get qrcode
+# Get QR Code
 # /instance/qr?key=KEY
 
 curl --location --request GET 'localhost:3333/instance/qr?key=123'
 ```
 
 ```sh
-#Send Message
-# /message/text?key=KEY&id=ID&message=MESSAGE
+# Send Message
+# /message/text?key=KEY&id=PHONE-NUMBER-WITH-COUNTRY-CODE&message=MESSAGE
 
 curl --location --request POST 'localhost:3333/message/text?key=123' \
 --header 'Content-Type: application/x-www-form-urlencoded' \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  server:
+    image: node:17.2.0-alpine
+    user: "node"
+    restart: unless-stopped
+    working_dir: /home/node/app
+    environment:
+      - TOKEN=${TOKEN}
+      - PORT=${PORT}
+      - MONGODB_ENABLED=${MONGODB_ENABLED}
+      - MONGODB_URL=${MONGODB_URL}
+      - WEBHOOK_ENABLED=${WEBHOOK_ENABLED}
+      - WEBHOOK_URL=${WEBHOOK_URL}
+      - WEBHOOK_BASE64=${WEBHOOK_BASE64}
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - ${PORT}:${PORT}
+    env_file:
+      - .env
+    command: "npm start"
+    depends_on:
+      - mongodb
+  mongodb:
+    image: mongo:latest
+    volumes:
+      - mongodb:/data/db
+volumes:
+  mongodb:

--- a/src/api/controllers/instance.controller.js
+++ b/src/api/controllers/instance.controller.js
@@ -1,19 +1,30 @@
 const { WhatsAppInstance } = require('../class/instance')
 const fs = require('fs')
 const path = require('path')
+const config = require('../../config/config')
 
 exports.init = async (req, res) => {
-    const key = req.query.key
-    const webhook = !req.query.webhook ? false : req.query.webhook
-    const webhookUrl = !req.query.webhookUrl ? null : req.query.webhookUrl
-    const instance = new WhatsAppInstance(key, webhook, webhookUrl)
-    const data = await instance.init()
-    WhatsAppInstances[data.key] = instance
-    res.json({
-        error: false,
-        message: 'Initializing successfully',
-        key: data.key,
-    })
+    const token = req.query.token
+    if (token !== config.token) {
+        res.status(403)
+        res.json({
+            error: true,
+            code: 403,
+            message: 'Unauthorized',
+        })
+    } else {
+        const key = req.query.key
+        const webhook = !req.query.webhook ? false : req.query.webhook
+        const webhookUrl = !req.query.webhookUrl ? null : req.query.webhookUrl
+        const instance = new WhatsAppInstance(key, webhook, webhookUrl)
+        const data = await instance.init()
+        WhatsAppInstances[data.key] = instance
+        res.json({
+            error: false,
+            message: 'Initializing successfully',
+            key: data.key,
+        })
+    }
 }
 
 exports.qr = async (req, res) => {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,5 +1,6 @@
 // Port number
 const PORT = process.env.PORT || '3333'
+const TOKEN = process.env.TOKEN || ''
 // Enable or disable mongodb
 const MONGODB_ENABLED = !!(
     process.env.MONGODB_ENABLED && process.env.MONGODB_ENABLED === 'true'
@@ -22,6 +23,7 @@ const WEBHOOK_BASE64 = !!(
 
 module.exports = {
     port: PORT,
+    token: TOKEN,
     mongoose: {
         enabled: MONGODB_ENABLED,
         url: MONGODB_URL,


### PR DESCRIPTION
I'm planning to expose the API to the internet and thought that adding a token to the init route would prevent spam/bad actors.