### PR TITLE
fix: Invalid data on save pre-keys

### DIFF
--- a/src/api/helper/mongoAuthState.js
+++ b/src/api/helper/mongoAuthState.js
@@ -99,12 +99,12 @@ module.exports = useMongoDBAuthState = async (collection) => {
                 },
                 set: async (data) => {
                     const tasks = []
-                    for (const category in data) {
-                        for (const id in data[category]) {
+                    for (const category of Object.keys(data)) {
+                        for (const id of Object.keys(data[category])) {
                             const value = data[category][id]
-                            const id = `${category}-${id}`
+                            const key = `${category}-${id}`
                             tasks.push(
-                                value ? writeData(value, id) : removeData(id)
+                                value ? writeData(value, key) : removeData(key)
                             )
                         }
                     }


### PR DESCRIPTION
Webhooks are broken because pre-keys are not being saved in the new database system. When this happens, messages are not decrypted and the webhook is not triggered as there is no valid message.