### PR TITLE
fix restore session constructor for customWebhook

### DIFF
--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -46,8 +46,8 @@ class WhatsAppInstance {
     constructor(key, allowWebhook, webhook) {
         this.key = key ? key : uuidv4()
         this.instance.customWebhook = this.webhook ? this.webhook : webhook
-        this.allowWebhook = config.allowWebhook
-            ? config.allowWebhook
+        this.allowWebhook = config.webhookEnabled
+            ? config.webhookEnabled
             : allowWebhook
         if (this.allowWebhook && this.instance.customWebhook !== null) {
             this.allowWebhook = true

--- a/src/api/class/session.js
+++ b/src/api/class/session.js
@@ -20,7 +20,7 @@ class Session {
                     .find(query)
                     .toArray(async (err, result) => {
                         if (err) throw err
-                        const webhook = !config.webhook ? undefined : config.webhookEnabled
+                        const webhook = !config.webhookEnabled ? undefined : config.webhookEnabled
                         const webhookUrl = !config.webhookUrl ? undefined : config.webhookUrl
                         const instance = new WhatsAppInstance(key, webhook, webhookUrl)
                         await instance.init()

--- a/src/api/class/session.js
+++ b/src/api/class/session.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unsafe-optional-chaining */
 const { WhatsAppInstance } = require('../class/instance')
 const logger = require('pino')()
+const config = require('../../config/config')
 
 class Session {
     async restoreSessions() {
@@ -19,7 +20,9 @@ class Session {
                     .find(query)
                     .toArray(async (err, result) => {
                         if (err) throw err
-                        const instance = new WhatsAppInstance(key)
+                        const webhook = !config.webhook ? undefined : config.webhookEnabled
+                        const webhookUrl = !config.webhookUrl ? undefined : config.webhookUrl
+                        const instance = new WhatsAppInstance(key, webhook, webhookUrl)
                         await instance.init()
                         WhatsAppInstances[key] = instance
                     })


### PR DESCRIPTION
this solves the constructor when I restore a session as without it the webhook was always starting as undefined