### PR TITLE
Update Postman to avoid error on  message/mediaurl

### DIFF
--- a/whatsapp-api-nodejs.postman_collection.json
+++ b/whatsapp-api-nodejs.postman_collection.json
@@ -630,8 +630,8 @@
 						"method": "POST",
 						"header": [],
 						"body": {
-							"mode": "formdata",
-							"formdata": [
+							"mode": "urlencoded",
+							"urlencoded": [
 								{
 									"key": "id",
 									"value": "",


### PR DESCRIPTION
Update Postman to avoid error on  message/mediaurl : TypeError: Cannot use 'in' operator to search for ... Cannot read properties of undefined (reading 'includes')