### PR TITLE
Fixed bug with buttons not sending to recipient correctly

### DIFF
--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -427,6 +427,7 @@ class WhatsAppInstance {
                 templateButtons: processButton(data.buttons),
                 text: data.text ?? '',
                 footer: data.footerText ?? '',
+                viewOnce: true
             }
         )
         return result
@@ -457,6 +458,7 @@ class WhatsAppInstance {
                 buttonText: data.buttonText,
                 footer: data.description,
                 title: data.title,
+                viewOnce: true
             }
         )
         return result
@@ -475,6 +477,7 @@ class WhatsAppInstance {
                 caption: data.text,
                 templateButtons: processButton(data.buttons),
                 mimetype: data.mimeType,
+                viewOnce: true
             }
         )
         return result


### PR DESCRIPTION
The bug that happens when sending buttons/list button no reach the receiver on android/ios was fixed with the attribute `viewOnce: true`.

The original contributor of this fix is here: https://github.com/adiwajshing/Baileys/issues/2376#issuecomment-1333834487