### PR TITLE
ignore loginVerify when deleting instance

### DIFF
--- a/src/api/routes/instance.route.js
+++ b/src/api/routes/instance.route.js
@@ -10,7 +10,7 @@ router.route('/qrbase64').get(keyVerify, controller.qrbase64)
 router.route('/info').get(keyVerify, controller.info)
 router.route('/restore').get(controller.restore)
 router.route('/logout').delete(keyVerify, loginVerify, controller.logout)
-router.route('/delete').delete(keyVerify, loginVerify, controller.delete)
+router.route('/delete').delete(keyVerify, controller.delete)
 router.route('/list').get(controller.list)
 
 module.exports = router


### PR DESCRIPTION
This pull request fixes an issue where the API was preventing the deletion of an instance, as the `loginVerify` middleware was used in the delete endpoint. The correct flow for deleting an instance should be as follows:

1) Perform logout
2) Delete the instance (so the instance is always in offline status when calling delete)

This pull request removes the `loginVerify` middleware from the delete instance endpoint. 

Closes #451 