### PR TITLE
Mark messages read

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ MONGODB_URL=mongodb://127.0.0.1:27017/whatsapp_api
 WEBHOOK_ENABLED=false
 WEBHOOK_URL=https://webhook.site/d0122a66-18a3-432d-b63f-4772b190dd72
 WEBHOOK_BASE64=false
+
+# ==================================
+# MESSAGE CONFIGURATION
+# ==================================
+MARK_MESSAGES_READ=false

--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -209,6 +209,18 @@ class WhatsAppInstance {
                 this.instance.messages.unshift(...m.messages)
             if (m.type !== 'notify') return
 
+            // https://adiwajshing.github.io/Baileys/#reading-messages
+            if (config.markMessagesRead) {
+                m.messages.map((async (msg) => {
+                    return {
+                        remoteJid: msg.key.remoteJid,
+                        id: msg.key.id,
+                        participant: msg.key.participant
+                    }
+                }))
+                await sock.readMessages([key])    
+            }
+
             this.instance.messages.unshift(...m.messages)
 
             m.messages.map(async (msg) => {

--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -202,7 +202,7 @@ class WhatsAppInstance {
         })
 
         // on new mssage
-        sock?.ev.on('messages.upsert', (m) => {
+        sock?.ev.on('messages.upsert', async (m) => {
             //console.log('messages.upsert')
             //console.log(m)
             if (m.type === 'prepend')
@@ -211,14 +211,14 @@ class WhatsAppInstance {
 
             // https://adiwajshing.github.io/Baileys/#reading-messages
             if (config.markMessagesRead) {
-                m.messages.map((async (msg) => {
+                const unreadMessages = m.messages.map(msg => {
                     return {
                         remoteJid: msg.key.remoteJid,
                         id: msg.key.id,
-                        participant: msg.key.participant
+                        participant: msg.key?.participant
                     }
-                }))
-                await sock.readMessages([key])    
+                })
+                await sock.readMessages(unreadMessages)
             }
 
             this.instance.messages.unshift(...m.messages)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -37,6 +37,10 @@ const WEBHOOK_URL = process.env.WEBHOOK_URL
 const WEBHOOK_BASE64 = !!(
     process.env.WEBHOOK_BASE64 && process.env.WEBHOOK_BASE64 === 'true'
 )
+// Mark messages as seen
+const MARK_MESSAGES_READ = !!(
+    process.env.MARK_MESSAGES_READ && process.env.MARK_MESSAGES_READ === 'true'
+)
 
 module.exports = {
     port: PORT,
@@ -67,4 +71,5 @@ module.exports = {
     webhookUrl: WEBHOOK_URL,
     webhookBase64: WEBHOOK_BASE64,
     protectRoutes: PROTECT_ROUTES,
+    markMessagesRead: MARK_MESSAGES_READ
 }


### PR DESCRIPTION
This pull request introduces a new environment variable `MARK_MESSAGES_READ` that can be used to mark messages as read.