### PR TITLE
Filter Webhook events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ MONGODB_URL=mongodb://127.0.0.1:27017/whatsapp_api
 WEBHOOK_ENABLED=false
 WEBHOOK_URL=https://webhook.site/d0122a66-18a3-432d-b63f-4772b190dd72
 WEBHOOK_BASE64=false
+WEBHOOK_ALLOWED_EVENTS=
 
 # ==================================
 # MESSAGE CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ Response:
     "key": "d7e2abff-3ac8-44a9-a738-1b28e0fca8a5"
 }
 ```
+## WEBHOOK_ALLOWED_EVENTS
+You can set which events you want to send to webhook by setting the environment variable `WEBHOOK_ALLOWED_EVENTS`
+
+Set a comma seperated list of events you want to get notified about. 
+
+Default value is `all` which will forward all events.
+
+Allowed values:
+- `connection` - receive all connection events
+- `connection:open` - receive open connection events
+- `connection:close` - receive close connection events
+- `presense` - receive presence events
+- `messages` - receive all messages event
+- `call` - receive all events related to calls
+- `call:terminate` - receive call terminate events
+- `call:offer` - receive call terminate event
+- `groups` - receive all events related to groups
+- `group_participants` - receive all events related to group participants
+
+You can also use the Baileys event format example: `messages.upsert`
 
 ## Generate custom instance with custom key and custom webhook.
 

--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -105,6 +105,7 @@ class WhatsAppInstance {
                     this.instance.online = false
                 }
 
+                if (['all', 'connection', 'connection.update', 'connection:close'].some((e) => config.webhookAllowedEvents.includes(f)))
                 await this.SendWebhook('connection', {
                     connection: connection,
                 }, this.key)
@@ -119,7 +120,7 @@ class WhatsAppInstance {
                     }
                 }
                 this.instance.online = true
-
+                if (['all', 'connection', 'connection.update', 'connection:open'].some((e) => config.webhookAllowedEvents.includes(f)))
                 await this.SendWebhook('connection', {
                     connection: connection,
                 }, this.key)
@@ -143,6 +144,7 @@ class WhatsAppInstance {
 
         // sending presence
         sock?.ev.on('presence.update', async (json) => {
+            if (['all', 'presence', 'presence.update'].some((e) => config.webhookAllowedEvents.includes(f)))
             await this.SendWebhook('presence', json, this.key)
         })
 
@@ -268,7 +270,7 @@ class WhatsAppInstance {
                             break
                     }
                 }
-
+                if (['all', 'messages', 'messages.upsert'].some((e) => config.webhookAllowedEvents.includes(f)))
                 await this.SendWebhook('message', webhookData, this.key)
             })
         })
@@ -281,7 +283,7 @@ class WhatsAppInstance {
             if (data.content) {
                 if (data.content.find((e) => e.tag === 'offer')) {
                     const content = data.content.find((e) => e.tag === 'offer')
-
+                    if (['all', 'call', 'CB:call', 'call:offer'].some((e) => config.webhookAllowedEvents.includes(f)))
                     await this.SendWebhook('call_offer', {
                         id: content.attrs['call-id'],
                         timestamp: parseInt(data.attrs.t),
@@ -296,6 +298,7 @@ class WhatsAppInstance {
                         (e) => e.tag === 'terminate'
                     )
 
+                    if (['all', 'call', 'call:terminate'].some((e) => config.webhookAllowedEvents.includes(f)))
                     await this.SendWebhook('call_terminate', {
                         id: content.attrs['call-id'],
                         user: {
@@ -312,6 +315,7 @@ class WhatsAppInstance {
             //console.log('groups.upsert')
             //console.log(newChat)
             this.createGroupByApp(newChat)
+            if (['all', 'groups', 'groups.upsert'].some((e) => config.webhookAllowedEvents.includes(f)))
             await this.SendWebhook('group_created', {
                 data: newChat,
             }, this.key)
@@ -321,6 +325,7 @@ class WhatsAppInstance {
             //console.log('groups.update')
             //console.log(newChat)
             this.updateGroupSubjectByApp(newChat)
+            if (['all', 'groups', 'groups.update'].some((e) => config.webhookAllowedEvents.includes(f)))
             await this.SendWebhook('group_updated', {
                 data: newChat,
             }, this.key)
@@ -330,6 +335,7 @@ class WhatsAppInstance {
             //console.log('group-participants.update')
             //console.log(newChat)
             this.updateGroupParticipantsByApp(newChat)
+            if (['all', 'groups', 'group_participants', 'group-participants.update'].some((e) => config.webhookAllowedEvents.includes(f)))
             await this.SendWebhook('group_participants_updated', {
                 data: newChat,
             }, this.key)

--- a/src/api/class/instance.js
+++ b/src/api/class/instance.js
@@ -105,7 +105,7 @@ class WhatsAppInstance {
                     this.instance.online = false
                 }
 
-                if (['all', 'connection', 'connection.update', 'connection:close'].some((e) => config.webhookAllowedEvents.includes(f)))
+                if (['all', 'connection', 'connection.update', 'connection:close'].some((e) => config.webhookAllowedEvents.includes(e)))
                 await this.SendWebhook('connection', {
                     connection: connection,
                 }, this.key)
@@ -120,7 +120,7 @@ class WhatsAppInstance {
                     }
                 }
                 this.instance.online = true
-                if (['all', 'connection', 'connection.update', 'connection:open'].some((e) => config.webhookAllowedEvents.includes(f)))
+                if (['all', 'connection', 'connection.update', 'connection:open'].some((e) => config.webhookAllowedEvents.includes(e)))
                 await this.SendWebhook('connection', {
                     connection: connection,
                 }, this.key)
@@ -144,7 +144,7 @@ class WhatsAppInstance {
 
         // sending presence
         sock?.ev.on('presence.update', async (json) => {
-            if (['all', 'presence', 'presence.update'].some((e) => config.webhookAllowedEvents.includes(f)))
+            if (['all', 'presence', 'presence.update'].some((e) => config.webhookAllowedEvents.includes(e)))
             await this.SendWebhook('presence', json, this.key)
         })
 
@@ -270,7 +270,7 @@ class WhatsAppInstance {
                             break
                     }
                 }
-                if (['all', 'messages', 'messages.upsert'].some((e) => config.webhookAllowedEvents.includes(f)))
+                if (['all', 'messages', 'messages.upsert'].some((e) => config.webhookAllowedEvents.includes(e)))
                 await this.SendWebhook('message', webhookData, this.key)
             })
         })
@@ -283,7 +283,7 @@ class WhatsAppInstance {
             if (data.content) {
                 if (data.content.find((e) => e.tag === 'offer')) {
                     const content = data.content.find((e) => e.tag === 'offer')
-                    if (['all', 'call', 'CB:call', 'call:offer'].some((e) => config.webhookAllowedEvents.includes(f)))
+                    if (['all', 'call', 'CB:call', 'call:offer'].some((e) => config.webhookAllowedEvents.includes(e)))
                     await this.SendWebhook('call_offer', {
                         id: content.attrs['call-id'],
                         timestamp: parseInt(data.attrs.t),
@@ -298,7 +298,7 @@ class WhatsAppInstance {
                         (e) => e.tag === 'terminate'
                     )
 
-                    if (['all', 'call', 'call:terminate'].some((e) => config.webhookAllowedEvents.includes(f)))
+                    if (['all', 'call', 'call:terminate'].some((e) => config.webhookAllowedEvents.includes(e)))
                     await this.SendWebhook('call_terminate', {
                         id: content.attrs['call-id'],
                         user: {
@@ -315,7 +315,7 @@ class WhatsAppInstance {
             //console.log('groups.upsert')
             //console.log(newChat)
             this.createGroupByApp(newChat)
-            if (['all', 'groups', 'groups.upsert'].some((e) => config.webhookAllowedEvents.includes(f)))
+            if (['all', 'groups', 'groups.upsert'].some((e) => config.webhookAllowedEvents.includes(e)))
             await this.SendWebhook('group_created', {
                 data: newChat,
             }, this.key)
@@ -325,7 +325,7 @@ class WhatsAppInstance {
             //console.log('groups.update')
             //console.log(newChat)
             this.updateGroupSubjectByApp(newChat)
-            if (['all', 'groups', 'groups.update'].some((e) => config.webhookAllowedEvents.includes(f)))
+            if (['all', 'groups', 'groups.update'].some((e) => config.webhookAllowedEvents.includes(e)))
             await this.SendWebhook('group_updated', {
                 data: newChat,
             }, this.key)
@@ -335,7 +335,7 @@ class WhatsAppInstance {
             //console.log('group-participants.update')
             //console.log(newChat)
             this.updateGroupParticipantsByApp(newChat)
-            if (['all', 'groups', 'group_participants', 'group-participants.update'].some((e) => config.webhookAllowedEvents.includes(f)))
+            if (['all', 'groups', 'group_participants', 'group-participants.update'].some((e) => config.webhookAllowedEvents.includes(e)))
             await this.SendWebhook('group_participants_updated', {
                 data: newChat,
             }, this.key)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -37,6 +37,8 @@ const WEBHOOK_URL = process.env.WEBHOOK_URL
 const WEBHOOK_BASE64 = !!(
     process.env.WEBHOOK_BASE64 && process.env.WEBHOOK_BASE64 === 'true'
 )
+// allowed events which should be sent to webhook
+const WEBHOOK_ALLOWED_EVENTS = process.env.WEBHOOK_ALLOWED_EVENTS?.split(',') || ['all']
 // Mark messages as seen
 const MARK_MESSAGES_READ = !!(
     process.env.MARK_MESSAGES_READ && process.env.MARK_MESSAGES_READ === 'true'
@@ -71,5 +73,6 @@ module.exports = {
     webhookUrl: WEBHOOK_URL,
     webhookBase64: WEBHOOK_BASE64,
     protectRoutes: PROTECT_ROUTES,
-    markMessagesRead: MARK_MESSAGES_READ
+    markMessagesRead: MARK_MESSAGES_READ,
+    webhookAllowedEvents: WEBHOOK_ALLOWED_EVENTS
 }


### PR DESCRIPTION
This pull request adds a new environment variable `WEBHOOK_ALLOWED_EVENTS` which can be used to configure which events you want to forward to webhook.

- [X] Updated Readme with all available events
- [X] Use `all` as the default value, which ensures the current behavior is maintained.